### PR TITLE
Upgrade to druid 0.11.0

### DIFF
--- a/defaults/main.yaml
+++ b/defaults/main.yaml
@@ -2,8 +2,8 @@
 # file: main.yaml
 
 # druid versions
-druid_version: 0.10.1
-druid_checksum: 3a32395305cc95c0cc351f2aa14de2f60ddd206ceb63e59a2b36bc96b98c421f
+druid_version: 0.11.0
+druid_checksum: d50218d11f97612acc1447914e113f1869997640de586daabd85828440c4c546
 
 # configuration
 druid_javascript_enabled: true

--- a/templates/_common/common.runtime.properties.j2
+++ b/templates/_common/common.runtime.properties.j2
@@ -33,6 +33,9 @@ druid.extensions.hadoopDependenciesDir=/opt/druid/druid-0.10.1/hadoop-dependenci
 # Log all runtime properties on startup. Disable to avoid logging properties on startup:
 druid.startup.logging.logProperties=true
 
+# Enable Double column storage - ONLY for druid v0.11.0 or later
+druid.indexing.doubleStorage=double
+
 #
 # Zookeeper
 #

--- a/templates/coordinator/runtime.properties
+++ b/templates/coordinator/runtime.properties
@@ -4,3 +4,4 @@ druid.port={{ druid_coordinator_port }}
 
 druid.coordinator.startDelay=PT30S
 druid.coordinator.period=PT30S
+druid.coordinator.balancer.strategy=cachingCost


### PR DESCRIPTION
 Fix: https://github.com/onaio/ansible-druid/issues/1

Upgrade to druid 0.11.0

- Enable double column support
- use the new cachingCost Balancer Strategy

Release notes for 0.11.0 https://github.com/druid-io/druid/releases
