### PR TITLE
Allow for Graphite White-list Monitoring

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,14 @@ By default we do not set monitors on the `broker`, `coordinator`, or `overlord`.
 They inherit their monitors from common. Uncomment at add list items to their
 respective properties in order to specify their monitors.
 
+The [Graphite Emitter](http://druid.io/docs/latest/development/extensions-contrib/graphite.html) allows for specifying the list of metrics to be sent. Define this list in the `druid_common_graphite_metric_whitelist` variable. The list of available metrics can be found [here](https://github.com/druid-io/druid/blob/master/extensions-contrib/graphite-emitter/src/main/resources/defaultWhiteListMap.json).
+
+```yml
+druid_emitter_graphite_metric_whitelist: |
+  "jvm/gc": [],
+  "jvm/mem": []
+```
+
 ### Middle manager log storage
 
 Task logs

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -29,6 +29,7 @@ druid_middlemanager_monitoring_monitors:
 druid_realtime_monitoring_monitors:
   - io.druid.java.util.metrics.JvmMonitor
   - io.druid.segment.realtime.RealtimeMetricsMonitor
+druid_emitter_graphite_metric_whitelist: ""
 
 # extensions
 druid_extensions:

--- a/tasks/config.yml
+++ b/tasks/config.yml
@@ -31,6 +31,24 @@
     mode: 0755
   become: yes
 
+- block:
+  - name: Make sure the graphite emitter conf directory exists
+    file:
+      path: "{{ druid_path }}conf/druid/_common/emitter/graphite"
+      state: directory
+      owner: "{{ druid_user }}"
+      mode: 0755
+    become: yes
+
+  - name: Copy over the the graphite metric whitelist file
+    template:
+      src: "_common/emitter/graphite/metric-whitelist.json.j2"
+      dest: "{{ druid_path }}conf/druid/_common/emitter/graphite/metric-whitelist.json"
+      owner: "{{ druid_user }}"
+      mode: 0755
+    become: yes
+  when: druid_emitter == "graphite" and druid_emitter_graphite_metric_whitelist != ""
+
 - name: Copy over specific configuration for Druid node {{ druid_role }}
   template:
     src: "{{ druid_role }}/runtime.properties"

--- a/templates/_common/emitter/graphite/metric-whitelist.json.j2
+++ b/templates/_common/emitter/graphite/metric-whitelist.json.j2
@@ -1,0 +1,3 @@
+{
+{{ druid_emitter_graphite_metric_whitelist }}
+}


### PR DESCRIPTION
When the Druid Emitter is set to Graphite, allow for setting the list of white-listed metrics to prevent Druid from sending all stats to Graphite.

More information on Graphite Emitter white-lists [here](http://druid.io/docs/latest/development/extensions-contrib/graphite.html).