### PR TITLE
Modify Graphite Whitelist Converter

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,12 +102,28 @@ By default we do not set monitors on the `broker`, `coordinator`, or `overlord`.
 They inherit their monitors from common. Uncomment at add list items to their
 respective properties in order to specify their monitors.
 
-The [Graphite Emitter](http://druid.io/docs/latest/development/extensions-contrib/graphite.html) allows for specifying the list of metrics to be sent. Define this list in the `druid_common_graphite_metric_whitelist` variable. The list of available metrics can be found [here](https://github.com/druid-io/druid/blob/master/extensions-contrib/graphite-emitter/src/main/resources/defaultWhiteListMap.json).
+The [Graphite Emitter](http://druid.io/docs/latest/development/extensions-contrib/graphite.html) allows for specifying the list of metrics to be sent.
+Define this list in the `druid_emitter_graphite_whitelist` variable. The list of
+available metrics can be found [here](https://github.com/druid-io/druid/blob/master/extensions-contrib/graphite-emitter/src/main/resources/defaultWhiteListMap.json).
 
 ```yml
-druid_emitter_graphite_metric_whitelist: |
+druid_emitter_graphite_whitelist: |2+
   "jvm/gc": [],
   "jvm/mem": []
+```
+
+By default `druid_emitter_graphite_whitelist_dir` is set to:
+
+```yml
+druid_emitter_graphite_whitelist_dir:
+  "{{ druid_path }}conf/druid/_common/emitter/graphite"
+```
+
+The whitelist can then be referenced in the emitter this way:
+
+```yml
+druid_emitter_configuration:
+  graphite.eventConverter: '{"type":"whitelist", "mapPath":"{{ druid_emitter_graphite_whitelist_dir }}/whitelist.json"}'
 ```
 
 ### Middle manager log storage

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -29,7 +29,8 @@ druid_middlemanager_monitoring_monitors:
 druid_realtime_monitoring_monitors:
   - io.druid.java.util.metrics.JvmMonitor
   - io.druid.segment.realtime.RealtimeMetricsMonitor
-druid_emitter_graphite_metric_whitelist: ""
+druid_emitter_graphite_whitelist: ""
+druid_emitter_graphite_whitelist_dir: "{{ druid_path }}conf/druid/_common/emitter/graphite"
 
 # extensions
 druid_extensions:

--- a/tasks/config.yml
+++ b/tasks/config.yml
@@ -34,7 +34,7 @@
 - block:
   - name: Make sure the graphite emitter conf directory exists
     file:
-      path: "{{ druid_path }}conf/druid/_common/emitter/graphite"
+      path: "{{ druid_emitter_graphite_whitelist_dir }}"
       state: directory
       owner: "{{ druid_user }}"
       mode: 0755
@@ -42,12 +42,12 @@
 
   - name: Copy over the the graphite metric whitelist file
     template:
-      src: "_common/emitter/graphite/metric-whitelist.json.j2"
-      dest: "{{ druid_path }}conf/druid/_common/emitter/graphite/metric-whitelist.json"
+      src: "_common/emitter/graphite/whitelist.json.j2"
+      dest: "{{ druid_emitter_graphite_whitelist_dir }}/whitelist.json"
       owner: "{{ druid_user }}"
       mode: 0755
     become: yes
-  when: druid_emitter == "graphite" and druid_emitter_graphite_metric_whitelist != ""
+  when: druid_emitter == "graphite" and druid_emitter_graphite_whitelist != ""
 
 - name: Copy over specific configuration for Druid node {{ druid_role }}
   template:

--- a/templates/_common/emitter/graphite/whitelist.json.j2
+++ b/templates/_common/emitter/graphite/whitelist.json.j2
@@ -1,0 +1,3 @@
+{
+{{ druid_emitter_graphite_whitelist }}
+}


### PR DESCRIPTION
Change the variable name for the Graphite whitelist to something less
verbose.

Also create a variable for defining the directory to put the whitelist
file.